### PR TITLE
added black to toml and requirements configuration for formatting

### DIFF
--- a/helper-scripts/requirements.txt
+++ b/helper-scripts/requirements.txt
@@ -130,3 +130,7 @@ if a security page opens click more options and run anyways
 
 install C++ redistributable at https://aka.ms/vs/17/release/vc_redist.x64.exe
 Just simply accept license and continue with install
+
+Black formatting: Open Settings
+    - Turn on 'Format On Save'
+    - If you want autoSave choose 'onFocusChange' instead of 'afterDelay'

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -19,5 +19,6 @@ robotpy_extras = [
 
 # Other pip packages to install
 requires = [
-    "numpy"
+    "numpy",
+    "black",
 ]


### PR DESCRIPTION
This updates pyproject.toml so that black is an automatically installed module when sync is run. I added instructions on how to get auto formatting working in VS Code even with auto save. This is not a code change.